### PR TITLE
Minor change in Motion Notifications section

### DIFF
--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -867,7 +867,7 @@
                     <tr class="settings-item advanced-setting" min="0" max="60" required="true" depends="emailNotificationsEnabled motionDetectionEnabled">
                         <td class="settings-item-label"><span class="settings-item-label">Attached Pictures Time Span</span></td>
                         <td class="settings-item-value"><input type="text" class="number styled notifications camera-config" id="emailPictureTimeSpanEntry"><span class="settings-item-unit">seconds</span></td>
-                        <td><span class="help-mark" title="defines the picture search time interval to use when creating email attachments (higher values generate emails with more pictures at the cost of an increased notification delay); set to 0 to disable picture attachments">?</span></td>
+                        <td><span class="help-mark" title="defines the picture search time interval to use when creating email attachments (higher values generate emails with more pictures at the cost of an increased notification delay). Note: for sending picture, you must enable 'Still Images' and set 'Capture Mode to Motion Triggered'; set to 0 to disable picture attachments">?</span></td>
                     </tr>
                     <tr class="settings-item advanced-setting" depends="emailNotificationsEnabled motionDetectionEnabled">
                         <td class="settings-item-label"><span class="settings-item-label"></span></td>


### PR DESCRIPTION
If 'still images' and set 'Capture Mode to Motion Triggered' are not set, you cannot receive the picture in the mail, to avoid the risk of errors, it's better to add the note in the tooltips.
